### PR TITLE
Fix header for ELPA compatibility

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -1,5 +1,13 @@
-;; ReVIEW編集支援モード
+;;; review-mode.el --- major mode for ReVIEW
+
 ;; Copyright 2007-2013 Kenshi Muto <kmuto@debian.org>
+
+;; Author: Kenshi Muto <kmuto@debian.org>
+;; URL: https://github.com/kmuto/review-el
+
+;;; Commentary:
+
+;; ReVIEW編集支援モード
 ;; License:
 ;;   GNU General Public License version 2 (see COPYING)
 
@@ -16,6 +24,8 @@
 ;; C-c [   【
 ;; C-c ]    】
 ;; C-c -    −
+
+;;; Code:
 
 (provide 'review-mode)
 (run-hooks 'review-load-hook)
@@ -653,3 +663,5 @@
 
 ;; Associate .re files with review-mode
 (setq auto-mode-alist (append '(("\\.re$" . review-mode)) auto-mode-alist))
+
+;;; review-mode.el ends here


### PR DESCRIPTION
This commit makes `review-mode.el` installable with package.el.

For information about this fix, See following GNU Emacs Manual:
- [Simple-Packages](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html)
- [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)
