### PR TITLE
Add autoload cookie to auto-mode-alist

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -662,6 +662,7 @@
 )
 
 ;; Associate .re files with review-mode
+;;;###autoload
 (setq auto-mode-alist (append '(("\\.re$" . review-mode)) auto-mode-alist))
 
 ;;; review-mode.el ends here


### PR DESCRIPTION
This commit ensures that users who have installed `review-mode` from [MELPA](http://melpa.milkbox.net/)  will be able to automatically turn on `review-mode` when visiting a `re` file without explicitly requiring the library first.
