### PR TITLE
Remove old review-change-mode-sub

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -576,14 +576,6 @@
   (setq mode-name review-mode-name)
   )
 
-(defun review-change-mode-sub (number)
-  "編集モード変更サブルーチン"
-  (let (list)
-    (setq list (nth number review-name-list))
-    (setq review-mode-name (car list))
-    )
-  )
-
 ;; DTP の変更
 (defun review-change-dtp ()
   (interactive)


### PR DESCRIPTION
`review-change-mode-sub` is defined twice. It seems That the former is unnecessary.
