### PR TITLE
Update faces for dark themes

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -270,12 +270,16 @@
   :group 'review-faces)
 
 (defface review-mode-underlinebold-face
-  '((t (:bold t :underline t :foreground "DarkBlue")))
+  '((default :weight bold :underline t)
+    (((class color) (background light)) :foreground "DarkBlue")
+    (((class color) (background dark)) :foreground "LightBlue"))
   "アンダーラインボールドのフェイス"
   :group 'review-faces)
 
 (defface review-mode-bold-face
-  '((t (:bold t :foreground "Blue")))
+  '((default :weight bold)
+    (((class color) (background light)) :foreground "Blue")
+    (((class color) (background dark)) :foreground "LightBlue"))
   "ボールドのフェイス"
   :group 'review-faces)
 

--- a/review-mode.el
+++ b/review-mode.el
@@ -299,7 +299,9 @@
   :group 'review-faces)
 
 (defface review-mode-hide-face
-  '((t (:bold t :foreground "plum4")))
+  '((((class color) (background light)) :foreground "plum4")
+    (((class color) (background dark)) :foreground "plum2")
+    (t :weight bold))
   "indexのフェイス"
   :group 'review-faces)
 
@@ -309,7 +311,9 @@
   :group 'review-faces)
 
 (defface review-mode-ref-face
-  '((t (:bold t :foreground "yellow4")))
+  '((((class color) (background light)) :foreground "yellow4")
+    (((class color) (background dark)) :foreground "yellow2")
+    (t :weight bold))
   "参照のフェイス"
   :group 'review-faces)
 

--- a/review-mode.el
+++ b/review-mode.el
@@ -223,32 +223,44 @@
   :group 'review-faces)
 
 (defface review-mode-title-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "タイトルのフェイス"
   :group 'review-faces)
 
 (defface review-mode-header1-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "ヘッダーのフェイス"
   :group 'review-faces)
 
 (defface review-mode-header2-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "ヘッダーのフェイス"
   :group 'review-faces)
 
 (defface review-mode-header3-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "ヘッダーのフェイス"
   :group 'review-faces)
 
 (defface review-mode-header4-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "ヘッダーのフェイス"
   :group 'review-faces)
 
 (defface review-mode-header5-face
-  '((t (:bold t :foreground "darkgreen")))
+  '((((class color) (background light)) :foreground "darkgreen")
+    (((class color) (background dark)) :foreground "spring green")
+    (t :weight bold))
   "ヘッダーのフェイス"
   :group 'review-faces)
 


### PR DESCRIPTION
## 問題

暗い背景のテーマで使うと、例えば数式の部分のface (`review-mode-bold-face`) などがとても暗くて見づらいと思いました。

## 変更したこと

背景が dark か light かによって色を変えるようにしました。

## 方法

`((class color) (background light))` と `((class color) (background dark))` に分けて face を定義すれば背景の明るさによって自動的に適用されます。


## 例として暗い背景のテーマである `blackboard` で試したスクリーンショット

### before

![image](https://user-images.githubusercontent.com/118150/96371737-3a90b880-119e-11eb-809a-f3136326c444.png)

### after

![image](https://user-images.githubusercontent.com/118150/96371772-6744d000-119e-11eb-8747-79f90a589021.png)


