### PR TITLE
enhance review-block-region

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -533,7 +533,7 @@ Key bindings:
 もしRegionが選択されていたら, その領域を指定したタグで囲みます。
 もしRegionが選択されていなかったら, 現在のポイントをタグで囲みます.
 もしARGありで呼ばれた場合は、Regionが選択されているかによらず,
-ポインタ位置より前の最も近いタグを変更します."
+カーソル位置より前の最も近いタグを変更します."
   (interactive "*P")
   (let* ((pattern (completing-read
                    (concat "タグ [" review-default-blockop "]: ")
@@ -548,36 +548,42 @@ Key bindings:
 (defun review-modify-previous-block (pattern)
   "現在位置をの一つ前のタグをPATTERNに変更する."
   (save-excursion
-    (re-search-backward (concat "//.+{"))
+    (re-search-backward (concat "//" ".+{"))
     (replace-match (concat "//" pattern "{"))
     ))
 
 (defun review-insert-block (pattern)
   "PATTERNタグを挿入する."
   (cond
-     ((region-active-p)
-	  (save-restriction
-	    (narrow-to-region (region-beginning) (region-end))
-	    (goto-char (point-min))
-	    (cond
-         ((member pattern review-block-op-single)
-		  (insert "//" pattern "\n"))
-	     (t
-		  (insert "//" pattern "{\n")
-		  (goto-char (point-max))
-		  (insert "//}\n")))))
+   ((region-active-p)
+	(save-restriction
+	  (narrow-to-region (region-beginning) (region-end))
+	  (goto-char (point-min))
+	  (cond
+       ((member pattern review-block-op-single)
+		(insert "//" pattern)
+        (newline))
+	   (t
+		(insert "//" pattern "{")
+        (newline)
+		(goto-char (point-max))
+		(insert "//" "}")
+        (newline)))))
+   (t
+	(cond
+     ((member pattern review-block-op-single)
+	  (insert "//" pattern)
+      (newline))
      (t
-	  (let ((review-position (point)))
-        (cond
-         ((member pattern review-block-op-single)
-		  (insert "//" pattern "\n"))
-	     (t
-		  (insert "//" pattern "{\n")
-		  (insert "//}\n")
-		  (goto-char review-position)
-		  (forward-word)
-	      )))))
-    )
+      (save-excursion
+        (insert "//" pattern "{")
+        (newline)
+		(insert "//" "}")
+        (newline))
+      (re-search-forward "{")
+	  )))
+   )
+)
 
 ;; beginchild/endchild囲み
 (defun review-child-region ()

--- a/review-mode.el
+++ b/review-mode.el
@@ -530,7 +530,7 @@ Key bindings:
 (defun review-block-region (arg)
   "選択領域を指定したタグで囲みます.
 
-もしRegionが選択されていたら, その領域を指定したタグで囲みます。
+もしRegionが選択されていたら, その領域を指定したタグで囲みます.
 もしRegionが選択されていなかったら, 現在のポイントをタグで囲みます.
 もしARGありで呼ばれた場合は、Regionが選択されているかによらず,
 カーソル位置より前の最も近いタグを変更します."
@@ -548,9 +548,10 @@ Key bindings:
 (defun review-modify-previous-block (pattern)
   "現在位置をの一つ前のタグをPATTERNに変更する."
   (save-excursion
-    (re-search-backward (concat "//" ".+{"))
-    (replace-match (concat "//" pattern "{"))
-    ))
+    (if (re-search-backward (concat "//" ".+{"))
+        (replace-match (concat "//" pattern "{"))
+      (message "カーソル位置より前にタグが見つかりません.")
+    )))
 
 (defun review-insert-block (pattern)
   "PATTERNタグを挿入する."

--- a/review-mode.el
+++ b/review-mode.el
@@ -580,10 +580,10 @@ Key bindings:
         (newline)
 		(insert "//" "}")
         (newline))
-      (re-search-forward "{")
-	  )))
-   )
-)
+      (forward-word)
+      (forward-char)
+      )))
+   ))
 
 ;; beginchild/endchild囲み
 (defun review-child-region ()

--- a/review-mode.el
+++ b/review-mode.el
@@ -527,38 +527,6 @@ Key bindings:
 
 ;; リージョン取り込み
 (defvar review-default-blockop "emlist")
-;; (defun review-block-region (pattern)
-;;   "選択領域を指定したタグで囲みます。"
-;;   (interactive
-;;    (list (completing-read
-;;           (concat "タグ [" review-default-blockop "]: ")
-;;           (append review-block-op review-block-op-single) nil nil)))
-;;   (let ((pattern (if (string= "" pattern) review-default-blockop pattern)))
-;;     (cond
-;;      ((region-active-p)
-;; 	  (save-restriction
-;; 	    (narrow-to-region (region-beginning) (region-end))
-;; 	    (goto-char (point-min))
-;; 	    (cond
-;;          ((member pattern review-block-op-single)
-;; 		  (insert "//" pattern "\n"))
-;; 		 (t
-;; 		  (insert "//" pattern "{\n")
-;; 		  (goto-char (point-max))
-;; 		  (insert "//}\n")))))
-;;      (t
-;; 	  (let ((review-position (point)))
-;;         (cond
-;;          ((member pattern review-block-op-single)
-;; 		  (insert "//" pattern "\n")
-;; 		  )
-;; 	     (t
-;; 		  (insert "//" pattern "{\n")
-;; 		  (insert "//}\n")
-;; 		  (goto-char review-position)
-;; 		  (forward-word)
-;; 	      )))))))
-
 (defun review-block-region (arg)
   "選択領域を指定したタグで囲みます.
 
@@ -632,7 +600,7 @@ Key bindings:
   (if (string= "" pattern)
       (setq pattern review-default-inlineop)
     (setq review-default-inlineop pattern))
-  
+
   (cond ((region-active-p)
 	 (save-restriction
 	   (narrow-to-region (region-beginning) (region-end))

--- a/review-mode.el
+++ b/review-mode.el
@@ -535,9 +535,9 @@ Key bindings:
   "選択領域を指定したタグで囲みます.
 
 もしRegionが選択されていたら, その領域を指定したタグで囲みます.
-もしRegionが選択されていなかったら, 現在のポイントをタグで囲みます.
-もしARGありで呼ばれた場合は、Regionが選択されているかによらず,
-カーソル位置より前の最も近いタグを変更します."
+もしRegionが選択されていなかったら, 現在のカーソル位置をタグで囲
+みます.  もしARGありで呼ばれた場合は、Regionが選択されているかに
+よらず, カーソル位置より前の, 最も近いタグを変更します."
   (interactive "*P")
   (let* ((pattern (completing-read
                    (concat "タグ [" review-default-blockop "]: ")
@@ -550,7 +550,7 @@ Key bindings:
       (review-insert-block pattern))))
 
 (defun review-modify-previous-block (pattern)
-  "現在位置をの一つ前のタグをPATTERNに変更する."
+  "現在位置の一つ前のタグをPATTERNに変更する."
   (save-excursion
     (if (re-search-backward (concat "//" ".+{"))
         (replace-match (concat "//" pattern "{"))


### PR DESCRIPTION
前置引数つきで呼ばれた場合カーソル位置より前の最も近いblockを変更する機能をつけました。
カーソル位置より前の、最も近くにあるblockが
//foo{
...
//}
である場合に、C-u C-c C-e barを実行すると
//bar{
...
//}
になります。

現在の実装だとblockの中にいようが外にいようが一つ前のものを変更してしまうので注意が必要です。本当はblockの中にいるかの判定をしたほうがよいのでしょうが、これでも個人的には十分便利だと思っているので提案します。