### PR TITLE
Fix a typo of definition of a face

### DIFF
--- a/review-mode.el
+++ b/review-mode.el
@@ -403,7 +403,7 @@ An alternative value is \" . \", if you use a font with a narrow period."
   :group 'review-faces)
 
 (defface review-mode-fullwidth-hyphen-minus-face
-  '((t (:foreground "grey90" :bkacground "red")))
+  '((t (:foreground "grey90" :background "red")))
   "全角ハイフン/マイナスのフェイス"
   :group 'review-faces)
 


### PR DESCRIPTION
Fix a typo of definition of the face `review-mode-fullwidth-hyphen-minus-face`.

 `review-mode-fullwidth-hyphen-minus-face` というフェイスの背景色の書き方にタイポがあるために、背景色が設定されなくなっているものを修正しました。

## Screenshots

修正前の全角ハイフン:

<img width="223" alt="スクリーンショット 2024-12-09 12 58 05" src="https://github.com/user-attachments/assets/66955817-4492-4855-82d4-4ab243a739e8">

修正後の全角ハイフン:

<img width="221" alt="スクリーンショット 2024-12-09 12 58 49" src="https://github.com/user-attachments/assets/742bbde8-238f-4f5f-831c-09e80e56c87a">
